### PR TITLE
Support schildichat:// links

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -243,6 +243,7 @@
                     android:host="room"
                     android:scheme="element" />
 
+                <data android:scheme="schildichat" />
             </intent-filter>
         </activity-alias>
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -75,6 +75,9 @@ import im.vector.app.features.spaces.share.ShareSpaceBottomSheet
 import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.workers.signout.ServerBackupStatusViewModel
 import im.vector.app.core.pushers.UPHelper
+import im.vector.app.features.permalink.PermalinkHandler.Companion.SC_MATRIX_TO_CUSTOM_SCHEME_URL_BASE
+import im.vector.app.features.permalink.PermalinkHandler.Companion.SC_ROOM_LINK_PREFIX
+import im.vector.app.features.permalink.PermalinkHandler.Companion.SC_USER_LINK_PREFIX
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -283,6 +286,15 @@ class HomeActivity :
                         activeSessionHolder.getSafeActiveSession()?.permalinkService()?.createPermalink(permalinkId)
                     }
                 }
+                deepLink.startsWith(SC_MATRIX_TO_CUSTOM_SCHEME_URL_BASE) -> {
+                    when {
+                        deepLink.startsWith(SC_USER_LINK_PREFIX) -> deepLink.substring(SC_USER_LINK_PREFIX.length)
+                        deepLink.startsWith(SC_ROOM_LINK_PREFIX) -> deepLink.substring(SC_ROOM_LINK_PREFIX.length)
+                        else                                     -> null
+                    }?.let { permalinkId ->
+                        activeSessionHolder.getSafeActiveSession()?.permalinkService()?.createPermalink(permalinkId)
+                    }
+                }
                 else                                                  -> deepLink
             }
 
@@ -295,7 +307,8 @@ class HomeActivity :
                 )
                 if (!isHandled) {
                     val isMatrixToLink = deepLink.startsWith(PermalinkService.MATRIX_TO_URL_BASE) ||
-                            deepLink.startsWith(MATRIX_TO_CUSTOM_SCHEME_URL_BASE)
+                            deepLink.startsWith(MATRIX_TO_CUSTOM_SCHEME_URL_BASE) ||
+                            deepLink.startsWith(SC_MATRIX_TO_CUSTOM_SCHEME_URL_BASE)
                     MaterialAlertDialogBuilder(this@HomeActivity)
                             .setTitle(R.string.dialog_title_error)
                             .setMessage(if (isMatrixToLink) R.string.permalink_malformed else R.string.universal_link_malformed)

--- a/vector/src/main/java/im/vector/app/features/link/LinkHandlerActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/link/LinkHandlerActivity.kt
@@ -67,6 +67,7 @@ class LinkHandlerActivity : VectorBaseActivity<ActivityProgressBinding>() {
             uri.getQueryParameter(LoginConfig.CONFIG_HS_PARAMETER) != null                 -> handleConfigUrl(uri)
             uri.toString().startsWith(PermalinkService.MATRIX_TO_URL_BASE)                 -> handleSupportedHostUrl()
             uri.toString().startsWith(PermalinkHandler.MATRIX_TO_CUSTOM_SCHEME_URL_BASE)   -> handleSupportedHostUrl()
+            uri.toString().startsWith(PermalinkHandler.SC_MATRIX_TO_CUSTOM_SCHEME_URL_BASE) -> handleSupportedHostUrl()
             resources.getStringArray(R.array.permalink_supported_hosts).contains(uri.host) -> handleSupportedHostUrl()
             else                                                                           -> {
                 // Other links are not yet handled, but should not come here (manifest configuration error?)

--- a/vector/src/main/java/im/vector/app/features/permalink/PermalinkHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/permalink/PermalinkHandler.kt
@@ -220,6 +220,9 @@ class PermalinkHandler @Inject constructor(private val activeSessionHolder: Acti
         const val MATRIX_TO_CUSTOM_SCHEME_URL_BASE = "element://"
         const val ROOM_LINK_PREFIX = "${MATRIX_TO_CUSTOM_SCHEME_URL_BASE}room/"
         const val USER_LINK_PREFIX = "${MATRIX_TO_CUSTOM_SCHEME_URL_BASE}user/"
+        const val SC_MATRIX_TO_CUSTOM_SCHEME_URL_BASE = "schildichat://"
+        const val SC_ROOM_LINK_PREFIX = "${SC_MATRIX_TO_CUSTOM_SCHEME_URL_BASE}room/"
+        const val SC_USER_LINK_PREFIX = "${SC_MATRIX_TO_CUSTOM_SCHEME_URL_BASE}user/"
     }
 }
 


### PR DESCRIPTION
We want to suppot schildichat:// links in addition to element:// links.

This change adds support for schildichat:// links of the same format as
the element links.

tested on a phone with android 11 and google chrome
schildichat://room/#web:schildi.chat

full disclosure this doesn't address https://github.com/vector-im/element-android/issues/5429 at all and there might be merge conflicts if that ever gets fixed (likely never)