### PR TITLE
Fix grammar in 2 strings in strings.xml

### DIFF
--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1577,9 +1577,9 @@
     <string name="room_list_catchup_empty_title">You’re all caught up!</string>
     <string name="room_list_catchup_empty_body">You have no more unread messages</string>
     <string name="room_list_people_empty_title">Conversations</string>
-    <string name="room_list_people_empty_body">Your direct message conversations will be displayed here. Tap the + bottom right to start some.</string>
+    <string name="room_list_people_empty_body">Your direct message conversations will be displayed here. Tap the + at the bottom right to start some.</string>
     <string name="room_list_rooms_empty_title">Rooms</string>
-    <string name="room_list_rooms_empty_body">Your rooms will be displayed here. Tap the + bottom right to find existing ones or start some of your own.</string>
+    <string name="room_list_rooms_empty_body">Your rooms will be displayed here. Tap the + at the bottom right to find existing ones or start some of your own.</string>
 
     <string name="title_activity_emoji_reaction_picker">Reactions</string>
     <string name="message_add_reaction">Add Reaction</string>


### PR DESCRIPTION
Line 1580 of [/vector/src/main/res/values/strings.xml](https://github.com/SchildiChat/SchildiChat-android/blob/sc/vector/src/main/res/values/strings.xml) reads

    <string name="room_list_people_empty_body">Your direct message conversations will be displayed here. Tap the + bottom right to start some.</string>

`Tap the + bottom right to start some` is a grammar mistake, so I changed it to `Tap the + at the bottom right to start some` instead.

In line 1582 it says something similar, so I corrected that as well.

This error is also part of upstream Element code.

Edit: Upstream PR is vector-im/element-android#6132