### PR TITLE
add split screen support

### DIFF
--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3417,6 +3417,10 @@
     <string name="labs_enable_client_info_recording_summary">Record the client name, version, and url to recognise sessions more easily in session manager.</string>
     <string name="labs_enable_voice_broadcast_title">Enable voice broadcast (under active development)</string>
     <string name="labs_enable_voice_broadcast_summary">Be able to record and send voice broadcast in room timeline.</string>
+    <string name="labs_enable_tablet_mode_title">Enable tablet mode (split screen)</string>
+    <string name="labs_enable_tablet_mode_summary">Allow Chats to be opened in split window.</string>
+    <string name="labs_enable_multichat_title">Enable multiwindow chats</string>
+    <string name="labs_enable_multichat_summary">Allow Multiple Chats to be opened in split windows (need tablet mode enabled).</string>
 
     <!-- Note to translators: %s will be replaces with selected space name -->
     <string name="home_empty_space_no_rooms_title">%s\nis looking a little empty.</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3417,10 +3417,6 @@
     <string name="labs_enable_client_info_recording_summary">Record the client name, version, and url to recognise sessions more easily in session manager.</string>
     <string name="labs_enable_voice_broadcast_title">Enable voice broadcast (under active development)</string>
     <string name="labs_enable_voice_broadcast_summary">Be able to record and send voice broadcast in room timeline.</string>
-    <string name="labs_enable_tablet_mode_title">Enable tablet mode (split screen)</string>
-    <string name="labs_enable_tablet_mode_summary">Allow Chats to be opened in split window.</string>
-    <string name="labs_enable_multichat_title">Enable multiwindow chats</string>
-    <string name="labs_enable_multichat_summary">Allow Multiple Chats to be opened in split windows (need tablet mode enabled).</string>
 
     <!-- Note to translators: %s will be replaces with selected space name -->
     <string name="home_empty_space_no_rooms_title">%s\nis looking a little empty.</string>

--- a/library/ui-strings/src/main/res/values/strings_sc.xml
+++ b/library/ui-strings/src/main/res/values/strings_sc.xml
@@ -214,4 +214,9 @@
     <string name="settings_initial_sync">Initial sync</string>
     <string name="settings_initial_sync_summary">Clear cache and reload from server</string>
 
+    <string name="labs_enable_tablet_mode_title">Enable tablet mode (split screen)</string>
+    <string name="labs_enable_tablet_mode_summary">Allow Chats to be opened in split window.</string>
+    <string name="labs_enable_multichat_title">Enable multiwindow chats</string>
+    <string name="labs_enable_multichat_summary">Allow Multiple Chats to be opened in split windows (need tablet mode enabled).</string>
+
 </resources>

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -85,9 +85,14 @@
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />
 
+        <meta-data
+            android:name="android.allow_multiple_resumed_activities"
+            android:value="true" />
+
         <activity
             android:name=".features.MainActivity"
-            android:theme="@style/AppTheme.Launcher.SC" />
+            android:theme="@style/AppTheme.Launcher.SC"
+            android:resizeableActivity="true"/>
 
         <activity android:name=".features.home.HomeActivity" />
 

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -177,6 +177,14 @@ class DefaultNavigator @Inject constructor(
 
         val args = TimelineArgs(roomId = roomId, eventId = eventId, isInviteAlreadyAccepted = isInviteAlreadyAccepted, openAtFirstUnread = openAtFirstUnread, openAnonymously = openAnonymously)
         val intent = RoomDetailActivity.newIntent(context, args, false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && vectorPreferences.isTabletModeEnabled()) {
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            if (vectorPreferences.isMultiChatEnabled()){
+                intent.flags = intent.flags or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+            } else {
+                intent.flags = intent.flags or Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+        }
         startActivity(context, intent, buildTask)
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -289,6 +289,9 @@ class VectorPreferences @Inject constructor(
         const val SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS = "SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS_"
         const val SETTINGS_NEW_LOGIN_ALERT_SHOWN_FOR_DEVICE = "SETTINGS_NEW_LOGIN_ALERT_SHOWN_FOR_DEVICE_"
 
+        const val SETTINGS_LABS_ENABLE_TABLET_MODE = "SETTINGS_LABS_ENABLE_TABLET_MODE"
+        const val SETTINGS_LABS_ENABLE_MULTICHAT = "SETTINGS_LABS_ENABLE_MULTICHAT"
+
         // Possible values for TAKE_PHOTO_VIDEO_MODE
         const val TAKE_PHOTO_VIDEO_MODE_ALWAYS_ASK = 0
         const val TAKE_PHOTO_VIDEO_MODE_PHOTO = 1
@@ -1557,5 +1560,14 @@ class VectorPreferences @Inject constructor(
         defaultPrefs.edit {
             putBoolean(SETTINGS_NEW_LOGIN_ALERT_SHOWN_FOR_DEVICE + deviceId, true)
         }
+    }
+
+    fun isTabletModeEnabled(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_TABLET_MODE, false)
+    }
+
+
+    fun isMultiChatEnabled(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_MULTICHAT, false)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
@@ -121,14 +121,29 @@ class VectorSettingsLabsFragment :
             pref.isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && vectorFeatures.isVoiceBroadcastEnabled()
         }
 
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_ENABLE_TABLET_MODE)?.let { pref ->
+            pref.isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+            pref.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                onTabletModePreferenceClicked()
+                true
+            }
+        }
+
         configureUnreadNotificationsAsTabPreference()
         configureEnableClientInfoRecordingPreference()
+        configureMultiChatPreference()
     }
 
     private fun configureUnreadNotificationsAsTabPreference() {
         findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB)?.let { pref ->
             pref.isVisible = !vectorFeatures.isNewAppLayoutFeatureEnabled()
             pref.isEnabled = !vectorPreferences.isNewAppLayoutEnabled()
+        }
+    }
+
+    private fun configureMultiChatPreference() {
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_ENABLE_MULTICHAT)?.let { pref ->
+            pref.isEnabled = vectorPreferences.isTabletModeEnabled()
         }
     }
 
@@ -178,6 +193,10 @@ class VectorSettingsLabsFragment :
      */
     private fun onNewLayoutPreferenceClicked() {
         configureUnreadNotificationsAsTabPreference()
+    }
+
+    private fun onTabletModePreferenceClicked() {
+        configureMultiChatPreference()
     }
 
     private fun configureEnableClientInfoRecordingPreference() {

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
@@ -143,6 +143,7 @@ class VectorSettingsLabsFragment :
 
     private fun configureMultiChatPreference() {
         findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_ENABLE_MULTICHAT)?.let { pref ->
+            pref.isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
             pref.isEnabled = vectorPreferences.isTabletModeEnabled()
         }
     }

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -43,6 +43,18 @@
             android:title="@string/url_previews_in_encrypted_rooms"
             android:summary="@string/url_previews_in_encrypted_rooms_summary" />
 
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="false"
+            android:key="SETTINGS_LABS_ENABLE_TABLET_MODE"
+            android:summary="@string/labs_enable_tablet_mode_summary"
+            android:title="@string/labs_enable_tablet_mode_title" />
+
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="false"
+            android:key="SETTINGS_LABS_ENABLE_MULTICHAT"
+            android:summary="@string/labs_enable_multichat_summary"
+            android:title="@string/labs_enable_multichat_title" />
+
     </im.vector.app.core.preference.VectorPreferenceCategory>
 
     <im.vector.app.core.preference.VectorPreferenceCategory


### PR DESCRIPTION
With android's multi windows support, it's easy to split two activities into two windows, which benefits tablet users.

Screen shots: 

![Screenshot_20230112_163144_SchildiChat dbg](https://user-images.githubusercontent.com/47494321/212017706-470657a0-2c4a-4fe7-80c6-27f74dce33e9.png)
![Screenshot_20230112_163343_SchildiChat dbg](https://user-images.githubusercontent.com/47494321/212018183-1e0573ff-e6af-470f-a95f-b3a283bef95c.png)

also I provided multi chat windows option for windowed mode android (like samsung's DeX mode)

![Screenshot_20230112_180024_One UI Home](https://user-images.githubusercontent.com/47494321/212037570-700cdb1d-5763-468e-97d9-33ff5758b8f5.png)

Those options are opt-in by default for compatibility.

![Screenshot_20230112_180112_One UI Home](https://user-images.githubusercontent.com/47494321/212038009-d1c71cb5-487c-42de-96ff-22a1969bcdf1.png)

reference: https://developer.android.com/guide/topics/large-screens/multi-window-support