### PR TITLE
Drop allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs in VectorWebViewActivity and WidgetWebView

### DIFF
--- a/vector/src/main/java/im/vector/app/features/webview/VectorWebViewActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/webview/VectorWebViewActivity.kt
@@ -55,10 +55,13 @@ class VectorWebViewActivity : VectorBaseActivity<ActivityVectorWebViewBinding>()
             // Allow use of Local Storage
             domStorageEnabled = true
 
-            @Suppress("DEPRECATION")
-            allowFileAccessFromFileURLs = true
-            @Suppress("DEPRECATION")
-            allowUniversalAccessFromFileURLs = true
+            // allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs
+            // only take effect when the main frame is a file:// URL. This
+            // WebView is launched with an http/https URL (see EXTRA_URL
+            // wiring), so neither flag is load-bearing here, and
+            // allowUniversalAccessFromFileURLs in particular is a
+            // CWE-200 sandbox-escape vector if a file:// load ever lands
+            // in this Activity.
 
             displayZoomControls = false
         }

--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
@@ -42,10 +42,11 @@ fun WebView.setupForWidget(activity: Activity,
     // Allow use of Local Storage
     settings.domStorageEnabled = true
 
-    @Suppress("DEPRECATION")
-    settings.allowFileAccessFromFileURLs = true
-    @Suppress("DEPRECATION")
-    settings.allowUniversalAccessFromFileURLs = true
+    // allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs
+    // only take effect when the main frame is a file:// URL. Widgets are
+    // always served from an https widget URL, so neither flag is
+    // load-bearing here, and allowUniversalAccessFromFileURLs in
+    // particular is a CWE-200 sandbox-escape vector.
 
     settings.displayZoomControls = false
 


### PR DESCRIPTION
Closes #284.

Two WebView setup paths still toggle the deprecated `allowFileAccessFromFileURLs` and `allowUniversalAccessFromFileURLs` flags even though neither WebView ever loads a `file://` main frame.

### VectorWebViewActivity

Launched with `EXTRA_URL` set to an http/https URL (identity-server terms pages, third-party-id links, etc.). The two flags only take effect on a `file://` main frame, so they do nothing for the actual launch paths.

### WidgetWebView

Widgets are served from the integration server's https widget URL. Same reasoning applies.

### Why drop them

`allowUniversalAccessFromFileURLs = true` lets a `file://` page XHR any origin (CWE-200, the classic sandbox escape). It is unsafe to leave on as a safety margin if a future code path ever loads a `file://` document into one of these WebViews. The `@Suppress("DEPRECATION")` annotations suggest the deprecation warning was acknowledged but the flags were never re-evaluated.

On pre-API-30 devices both flags default to `true`, so removing the explicit `= true` lines is a tightening on those devices rather than a no-op only on API 30+.

### Scope

Two files, four lines removed, two short comments added explaining why. No other WebView setting touched.

(The same flags also live in the matching upstream files in `element-hq/element-android`. This PR covers the SchildiChat tree only.)